### PR TITLE
main: Add main() and starting application

### DIFF
--- a/src/GameBox/Application.vala
+++ b/src/GameBox/Application.vala
@@ -1,0 +1,27 @@
+// This file is part of GameBox. License: GPL3
+
+namespace GameBox
+{
+    /**
+     * The application that manages the GameBox process. Instantiated in the
+     * main()-function.
+     */
+    public class Application : Gtk.Application
+    {
+        /**
+         * Constructs a new GameBox.Application.
+         */
+        public Application()
+        {
+            Object(application_id: "gamebox.application",
+                   flags:          ApplicationFlags.FLAGS_NONE);
+        }
+
+        // Inherited documentation.
+        protected override void activate()
+        {
+            // Don't do anything for now. Just let the application start up and
+            // shut down again.
+        }
+    }
+}

--- a/src/gamebox.vala
+++ b/src/gamebox.vala
@@ -1,0 +1,13 @@
+// This file is part of GameBox. License: GPL3
+
+/**
+ * Entry point for this application.
+ * @param args Input arguments.
+ * @returns    0 means program exited without errors, else errors
+ *             occured during exit.
+ */
+public int main(string[] args)
+{
+    GameBox.Application app = new GameBox.Application();
+    return app.run(args);
+}


### PR DESCRIPTION
Define an entry point `main()` and add an Application-class that
manages the GameBox process. Can be compiled with

```
valac --pkg="gtk+-3.0" --directory="./build" --basedir="./src"
```

from the root directory.
The program now does nothing but to start up and shut down.
