### PR TITLE
Use CMake configuration files for build time constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 # build directory
 build/*
 
+# Already configurated files.
+src/GameBox/BuildConfiguration.vala
+

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ build/*
 # Already configurated files.
 src/GameBox/BuildConfiguration.vala
 
+# .gresource.xml is copied into the source directory in build-time because the
+# paths inside of the resources are relative to it's location.
+src/.gresource.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Object files
+*.o
+
+# Executables
+*.exe
+
+# Temporary editor files
+*~
+*.swp
+
+# patches, patch related files
+*.orig
+*.patch
+*.diff
+
+# build directory
+build/*
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,17 @@ if (RESOURCES)
     message(STATUS "Copied ${XML_FILE_NAME} to source directory.")
     list(APPEND VALA_OPTIONS
          "--gresources=${CMAKE_SOURCE_DIR}/${XML_FILE_NAME}")
+
+    # Configure build configuration.
+    string(REPLACE "${CMAKE_BINARY_DIR}/" "" GameBox_RESOURCE_RELATIVE_TO_EXE
+           ${RESOURCE_OUT})
+    configure_file(${CMAKE_CURRENT_LIST_DIR}/GameBox/BuildConfiguration.vala.in
+                   ${CMAKE_CURRENT_LIST_DIR}/GameBox/BuildConfiguration.vala)
+    # Process configured file name to add to the vala sources.
+    string(REPLACE "${PROJECT_SOURCE_DIR}" "" CMAKE_CURRENT_LIST_DIR_RELATIVE
+                   "${CMAKE_CURRENT_LIST_DIR}")
+    list(APPEND SOURCES
+         ${CMAKE_CURRENT_LIST_DIR_RELATIVE}/GameBox/BuildConfiguration.vala)
 endif()
 
 # Precompile the C-files from Vala compiler and place them into "VALA_C".

--- a/src/GameBox/BuildConfiguration.vala.in
+++ b/src/GameBox/BuildConfiguration.vala.in
@@ -1,0 +1,15 @@
+// This file is part of GameBox. License: GPL3
+
+// THIS FILE IS GENERATED! DO NOT MODIFY!
+// IF YOU WANT TO REFRESH THE BUILD CONFIGURATION, INVOKE THE MAKEFILE AGAIN SO 
+// CMAKE CAN CONFIGURE THIS FILE!
+
+namespace GameBox.BuildConfiguration
+{
+    const uint VersionMajor = ${GameBox_VERSION_MAJOR};
+    const uint VersionMinor = ${GameBox_VERSION_MINOR};
+    const uint VersionMicro = ${GameBox_VERSION_MICRO};
+
+    const string ResourcePath = "${GameBox_RESOURCE_RELATIVE_TO_EXE}";
+}
+

--- a/src/GameBox/Resources.vala
+++ b/src/GameBox/Resources.vala
@@ -16,12 +16,11 @@ namespace GameBox
             m_Instance = null;
         }
 
-        // TODO: Use a configuration.in file in CMake to generate this constant
-        //       from the gresource build.
         /**
          * The location of the resource file relative to the executable.
          */
-        private static const string RESOURCE_FILE = "resources.gresource";
+        private static const string RESOURCE_FILE =
+            GameBox.BuildConfiguration.ResourcePath;
 
         /**
          * The maximum buffer length, for security and RAM-limitation purposes.

--- a/src/GameBox/UI/CMakeLists.txt
+++ b/src/GameBox/UI/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND SOURCES
 )
 
 list(APPEND RESOURCES
-    ${CMAKE_CURRENT_LIST_DIR_RELATIVE}/ApplicationWindow.ui
+    STRIPBLANKS ${CMAKE_CURRENT_LIST_DIR_RELATIVE}/ApplicationWindow.ui
 )
 
 # Append to parent variable.


### PR DESCRIPTION
Also introduces a .gitignore and improves resource handling in one place (_src/GameBox/UI/ApplicationWindow.ui_),
